### PR TITLE
fix detection encoding in emacs-style lines

### DIFF
--- a/swank-backend.lisp
+++ b/swank-backend.lisp
@@ -470,7 +470,7 @@ Return nil if the file contains no special markers."
       (loop while (and (< p end)
                        (member (aref str p) '(#\space #\tab)))
             do (incf p))
-      (let ((end (position-if (lambda (c) (find c '(#\space #\tab #\newline)))
+      (let ((end (position-if (lambda (c) (find c '(#\space #\tab #\newline #\;)))
                               str :start p)))
         (find-external-format (subseq str p end))))))
 


### PR DESCRIPTION
When encoding name in Emacs-style first line like ";; -*- coding: utf-8; other: stuff -*-" is immediately followed by a semicolon, SLIME failed to detect an encoding correctly. This is fixed by suggested change.